### PR TITLE
Add restore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,35 @@ let restore = mockedEnv(
 
 Again, calling `restore()` will restore the original full `process.env` object.
 
+### Restore environment without clearing
+
+If you want to maintain the current environment and restore it to the original state after restore() is called, pass the 'restore' option.
+
+```js
+let restore = mockedEnv(
+  {
+    FOO: 'foo',
+    BAR: 'bar',
+  },
+  { restore: true }
+)
+// process.env = {...process.env, FOO: 'foo', BAR: 'bar'}
+```
+
+These options are mutually exclusive and specifying them both will result in an error.
+
+### Options as first argument
+
+The options array can be passed as the first argument to the `mockedEnv` function as long as it contains either a 'restore' or 'clear' key, not both.
+
+```js
+let restore = mockedEnv(
+  { clear: true }
+)
+// process.env = {}
+```
+
+
 **⚠️ Note:** `process.env` values should always be strings ([Stackoverflow][1]), any call to `mockedEnv` that attempts to use values other than strings (or `undefined` to signify that a property should be deleted) will raise an error.
 
 ## Example

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "semantic-release": "semantic-release",
     "travis-deploy-once": "travis-deploy-once"
   },
+  "types": "src/index.d.ts",
   "devDependencies": {
     "ban-sensitive-files": "1.9.2",
     "dependency-check": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "files": [
     "src/*.js",
+    "src/index.d.ts",
     "!src/*-spec.js"
   ],
   "homepage": "https://github.com/bahmutov/mocked-env#readme",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,37 @@
+interface EnvVars {
+    [varName: string]: string
+}
+
+type MockedEnvOptions =
+    {
+        clear: boolean
+    } |
+    {
+        restore: boolean
+    };
+
+type RestoreFn = () => void;
+
+/**
+ * Mocks the current 'process.env' environment specifying the given vars as values and returns a "Restore Function" that
+ * when called, restores the environment values to the prior specified values.  Specifying 'undefined' for a value will
+ * temporarily delete the environment variable (until the restore function is called).
+ *
+ * If the 'clear' option is specified, the current process.env is cloned and cleared before setting the values and
+ * restored when the Restore Function is called.
+ *
+ * If the 'restore' option is specified, the current process.env is cloned before setting the values and restored when
+ * the Restore Function is called
+ *
+ * Either 'clear' or 'restore' can be used to ensure variables set during the test by code under test does not
+ * pollute the process environment.
+ *
+ * @param vars The environment variables to set (keys and values are both strings). Optional
+ * @param options Object to specify 'clear' or 'restore' option. Optional
+ * @return the Restore Function which should be called to restore the environment
+ */
+declare function mockedEnv(vars: EnvVars, options: MockedEnvOptions): RestoreFn;
+declare function mockedEnv(options: MockedEnvOptions): RestoreFn;
+declare function mockedEnv(vars: EnvVars): RestoreFn;
+
+export = mockedEnv;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,4 +34,4 @@ declare function mockedEnv(vars: EnvVars, options: MockedEnvOptions): RestoreFn;
 declare function mockedEnv(options: MockedEnvOptions): RestoreFn;
 declare function mockedEnv(vars: EnvVars): RestoreFn;
 
-export = mockedEnv;
+export default mockedEnv;

--- a/src/index.js
+++ b/src/index.js
@@ -19,10 +19,11 @@ const mockEnv = (changeVariables, options) => {
 
   // if the 2nd argument is undefined and first argument is an object with only 1 key of 'clear' or 'restore'
   // assume it is options and the changed variables are not set
-  const changedVariableNames = R.keys(changeVariables)
+  let changedVariableNames = R.keys(changeVariables)
   if (options === undefined && changedVariableNames.length === 1 && (changedVariableNames[0] === 'clear' || changedVariableNames[0] === 'reset')) {
-    options = R.clone(changedVariableNames)
-    changedVariableNames.length = 0
+    options = {}
+    options[changedVariableNames[0]] = changeVariables[changedVariableNames[0]]
+    changedVariableNames = []
   }
   const defaults = {
     clear: false

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ const mockEnv = (changeVariables, options = {}) => {
     process.env = backupEnv
   }
 
-  return options.clear ? restoreBackupEnv : restoreSome
+  return options.clear || options.restore ? restoreBackupEnv : restoreSome
 }
 
 module.exports = mockEnv

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,8 @@ const mockEnv = (changeVariables, options) => {
     changedVariableNames = []
   }
   const defaults = {
-    clear: false
+    clear: false,
+    restore: false
   }
   options = R.merge(defaults, options || {})
 

--- a/src/index.js
+++ b/src/index.js
@@ -101,3 +101,6 @@ const mockEnv = (changeVariables, options) => {
 }
 
 module.exports = mockEnv
+
+// Support for ES6 style imports
+module.exports.default = mockEnv

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,10 @@ const mockEnv = (changeVariables, options) => {
     restore: false
   }
   options = R.merge(defaults, options || {})
+  la(
+    options.clear === false || options.restore === false,
+    "only one of 'clear' or 'restore' may be supplied as an option"
+  )
 
   // make sure each new value is a string or undefined
   // because process.env values are cast as strings when the program starts

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@ const mockEnv = (changeVariables, options) => {
   debug(changeVariables)
   debug('options')
   debug(options)
- 
   la(
     is.object(changeVariables),
     'expected first argument to be an object of env variables or the options',
@@ -20,7 +19,12 @@ const mockEnv = (changeVariables, options) => {
   // if the 2nd argument is undefined and first argument is an object with only 1 key of 'clear' or 'restore'
   // assume it is options and the changed variables are not set
   let changedVariableNames = R.keys(changeVariables)
-  if (options === undefined && changedVariableNames.length === 1 && (changedVariableNames[0] === 'clear' || changedVariableNames[0] === 'reset')) {
+  if (
+    options === undefined &&
+    changedVariableNames.length === 1 &&
+    (changedVariableNames[0] === 'clear' ||
+      changedVariableNames[0] === 'restore')
+  ) {
     options = {}
     options[changedVariableNames[0]] = changeVariables[changedVariableNames[0]]
     changedVariableNames = []

--- a/src/mocked-env-spec.js
+++ b/src/mocked-env-spec.js
@@ -189,4 +189,68 @@ describe('mocked-env', () => {
       restore()
     })
   })
+
+  describe('restoring process.env', () => {
+    let restore
+    let defaultEnv
+
+    beforeEach(() => {
+      defaultEnv = R.clone(process.env)
+      process.env.BANG = 'bash'
+      restore = mockedEnv(
+        {
+          FOO: 'foo',
+          BAR: 'bar'
+        },
+        { restore: true }
+      )
+    })
+
+    it('has default env, BANG, FOO and BAR', () => {
+      const expected = R.merge(defaultEnv, {
+        FOO: 'foo',
+        BAR: 'bar',
+        BANG: 'bash'
+      })
+      la(
+        R.equals(process.env)(expected),
+        'expected process.env to be',
+        expected,
+        'but it was',
+        process.env
+      )
+    })
+
+    afterEach(() => {
+      restore()
+    })
+  })
+
+  describe('options as first argument', () => {
+    it("pass 'restore' in options", () => {
+      process.env.FOO = 'bar'
+      const restore = mockedEnv({ restore: true })
+      la(
+        R.equals(process.env.FOO)('bar'),
+        'expected environment to be maintained'
+      )
+      process.env.FOO = 'bash'
+      restore()
+      la(
+        R.equals(process.env.FOO)('bar'),
+        'expected environment to be restored'
+      )
+    })
+    it("pass 'clear' in options", () => {
+      process.env.FOO = 'bar'
+      const restore = mockedEnv({ clear: true })
+      la(process.env.FOO === undefined, 'expected environment to be clear')
+      process.env.FOO = 'bash'
+      restore()
+      la(
+        R.equals(process.env.FOO)('bar'),
+        'expected environment to be restored'
+      )
+    })
+  })
 })

--- a/src/mocked-env-spec.js
+++ b/src/mocked-env-spec.js
@@ -158,6 +158,20 @@ describe('mocked-env', () => {
     })
   })
 
+  it("'clear' and 'restore' result in error", () => {
+    is.raises(
+      () => {
+        mockedEnv({
+          clear: true,
+          restore: true
+        })
+      },
+      e => {
+        return e.message.includes('only one of')
+      }
+    )
+  })
+
   describe('clearing process.env', () => {
     let restore
 


### PR DESCRIPTION
Some tests may want to use the natural system environment but then restore it completely after the test (so that any environment variables added during the test get removed).  Adding a 'restore' option allows for this.