### PR TITLE
Add support for strict null checks and export type RestoreFn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 npm-debug.log
+.idea/

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 interface EnvVars {
-    [varName: string]: string
+    [varName: string]: string | undefined
 }
 
 type MockedEnvOptions =
@@ -10,7 +10,7 @@ type MockedEnvOptions =
         restore: boolean
     };
 
-type RestoreFn = () => void;
+export type RestoreFn = () => void;
 
 /**
  * Mocks the current 'process.env' environment specifying the given vars as values and returns a "Restore Function" that


### PR DESCRIPTION
This adds support for strict null checks so that you can now specify "undefined" as a passed in a variable.

It also exports the RestoreFn type

Simple use

```
import mockedEnv, {RestoreFn} from "mocked-env"

let restore: RestoreFn

restore = mockedEnv({
    "SOMETHING": "",
    "OTHER": undefined
})

restore()
```

- closes #144