### PR TITLE
Export types for EnvVars, MockedEnvOptions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,8 +1,8 @@
-interface EnvVars {
+export interface EnvVars {
     [varName: string]: string | undefined
 }
 
-type MockedEnvOptions =
+export type MockedEnvOptions =
     {
         clear: boolean
     } |


### PR DESCRIPTION
## Background
While I was writing my test code, I needed to wrap the `mockedEnv` function again like the following:
```tsx
// Some outer scope
let restoreEnv: RestoreFn = () => {};
afterEach(() => {
  restoreEnv();
});

const mockEnvironmentVariables = (variables: EnvVars) => {
   ...
  restoreEnv = mockedEnv(variables);
}
```
The type interface `EnvVars` isn't exported from the module; it has to be defined in my codebase again, hurting my context.

## Changes
- I made changes so this library exports the interface `EnvVars` so it can be used outside.
- Also exported the `MockedEnvOptions` for similar needs.